### PR TITLE
add svg export logic, click handler and styling

### DIFF
--- a/src/component/index.js
+++ b/src/component/index.js
@@ -18,6 +18,88 @@ const header = [
   'rankdir="LR"',
 ];
 
+function handleSaveSvg() {
+
+  let domUrl = window.URL || window.webkitURL || window;
+  //border around object on export
+  let margin = 0;
+
+  if (!domUrl) {
+    throw new Error(`(Browser does not support URI action ${domUrl})`)
+  }
+
+  // dynamically created viz doesn't have an id
+  let src = document.querySelector(`.${styles.wrapper} > svg`);
+
+  //get svg source
+  let serializer = new XMLSerializer();
+  let svgText = String(serializer.serializeToString(src));
+
+  // it needs a namespace
+  if (!svgText.match(/xmlns=\"/mi)){ //throws
+    svgText = svgText.replace ('<svg ','<svg xmlns="http://www.w3.org/2000/svg" ') ;  
+  }
+
+  // make a blob from the svg
+  let svg = new Blob([svgText], {
+    type: "image/svg+xml;charset=utf-8"
+  });
+
+  let url = domUrl.createObjectURL(svg);
+
+  // figure out the height and width from svg text
+  let matchH = (svgText).match(/height=\"(\d+)/m);
+  let height = matchH && matchH[1] ? parseInt(matchH[1],10) : 200;
+  let matchW = (svgText).match(/width=\"(\d+)/m);
+  let width = matchW && matchW[1] ? parseInt(matchW[1],10) : 200;
+
+  // create a canvas element to pass through
+  let canvas = document.createElement("canvas");
+  canvas.width = height+margin*2;
+  canvas.height = width+margin*2;
+  let ctx = canvas.getContext("2d");
+
+  // create a new image to hold the converted type
+  let img = new Image;
+        
+  // when the image is loaded we can get it as base64 url
+  img.onload = function() {
+    // draw it to the canvas
+    ctx.drawImage(this, margin, margin);
+    
+    //optional fill - no client support at the moment
+    // if it needs some styling, we need a new canvas
+    // if (fill) {
+    //   var styled = document.createElement("canvas");
+    //   styled.width = canvas.width;
+    //   styled.height = canvas.height;
+    //   var styledCtx = styled.getContext("2d");
+    //   styledCtx.save();
+    //   styledCtx.fillStyle = fill;   
+    //   styledCtx.fillRect(0,0,canvas.width,canvas.height);
+    //   styledCtx.strokeRect(0,0,canvas.width,canvas.height);
+    //   styledCtx.restore();
+    //   styledCtx.drawImage (canvas, 0,0);
+    //   canvas = styled;
+    // }
+
+    // we don't need the original any more
+    domUrl.revokeObjectURL(url);
+  };
+  
+  // load the image
+  img.src = url;
+
+  // pop up a download modal
+  // must create element on the dom for firefox
+  var downloadLink = document.createElement("a");
+  downloadLink.href = img.src;
+  downloadLink.download = "ContentModel.svg";
+  document.body.appendChild(downloadLink);
+  downloadLink.click();
+  document.body.removeChild(downloadLink);
+}
+
 const footer = ['}'];
 
 const removeExplicitDimensions = svgHtml =>
@@ -43,7 +125,10 @@ const ContentModelGraph = ({ Switch, types }) => {
   return (
     <div className={styles.container}>
       <h1>Content Model Graph</h1>
+      <div className={styles.interactiveComponents}>
       <Switch checked={isShowingFields} label="Show fields" onChange={() => setIsShowingFields(!isShowingFields)} />
+        <button onClick={handleSaveSvg}>Save</button>
+      </div>
       <div
         className={styles.wrapper}
         // eslint-disable-next-line react/no-danger

--- a/src/component/styles.css
+++ b/src/component/styles.css
@@ -12,3 +12,10 @@ svg {
   display: block;
   max-width: 1500px;
 }
+
+.interactiveComponents{
+  display: inline-flex;
+}
+  .interactiveComponents > *{
+    margin: 0 1rem;
+  }


### PR DESCRIPTION
Add 'save' button to plugin that will export your currently viewed graph as an svg.

Tested in Firefox and Chrome for Mac